### PR TITLE
Change how test revisions are specified.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::env;
 
 const USAGE: &'static str = "
 Usage: cargo-incremental build [options]
-       cargo-incremental replay [options] <branch-name>
+       cargo-incremental replay [options] <revisions>
        cargo-incremental --help
 
 This is a tool for testing incremental compilation. It offers two main
@@ -46,7 +46,6 @@ contents. =)
 
 Options:
     --cargo CARGO      path to Cargo.toml [default: Cargo.toml]
-    --revisions REV    range of revisions to test [default: HEAD~5..HEAD]
     --work-dir DIR     directory where we can do our work [default: work]
     --just-current     track just the current projection incrementally, not all deps
     --cli-log          print all sub-process output instead of writing to files
@@ -60,8 +59,7 @@ pub struct Args {
     cmd_replay: bool,
     arg_arguments: Vec<String>,
     flag_cargo: String,
-    arg_branch_name: String,
-    flag_revisions: String,
+    arg_revisions: String,
     flag_work_dir: String,
     flag_just_current: bool,
     flag_cli_log: bool,

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -15,8 +15,7 @@ use super::util::{cargo_build, CompilationStats, IncrementalOptions, TestResult,
 
 pub fn replay(args: &Args) {
     assert!(args.cmd_replay);
-    debug!("replay(): branch = {}", args.arg_branch_name);
-    debug!("replay(): revisions = {}", args.flag_revisions);
+    debug!("replay(): revisions = {}", args.arg_revisions);
 
     let cargo_toml_path = Path::new(&args.flag_cargo);
 
@@ -39,17 +38,14 @@ pub fn replay(args: &Args) {
 
     util::check_clean(repo);
 
-    // Set HEAD to the branch we are interested in
-    util::checkout_branch(repo, &args.arg_branch_name);
-
     // Filter down to the range of revisions specified by the user
     let (from_commit, to_commit);
-    if args.flag_revisions.contains("..") {
-        let revisions = match repo.revparse(&args.flag_revisions) {
+    if args.arg_revisions.contains("..") {
+        let revisions = match repo.revparse(&args.arg_revisions) {
             Ok(revspec) => revspec,
             Err(err) => {
                 error!("failed to parse revspec `{}`: {}",
-                       args.flag_revisions,
+                       args.arg_revisions,
                        err)
             }
         };
@@ -59,7 +55,7 @@ pub fn replay(args: &Args) {
             Some(object) => Some(util::commit_or_error(object.clone())),
             None => {
                 error!("revspec `{}` had no \"from\" point specified",
-                       args.flag_revisions)
+                       args.arg_revisions)
             }
         };
 
@@ -67,17 +63,17 @@ pub fn replay(args: &Args) {
             Some(object) => util::commit_or_error(object.clone()),
             None => {
                 error!("revspec `{}` had no \"to\" point specified; try something like `{}..HEAD`",
-                       args.flag_revisions,
-                       args.flag_revisions)
+                       args.arg_revisions,
+                       args.arg_revisions)
             }
         };
     } else {
         from_commit = None;
-        to_commit = match repo.revparse_single(&args.flag_revisions) {
+        to_commit = match repo.revparse_single(&args.arg_revisions) {
             Ok(revspec) => util::commit_or_error(revspec),
             Err(err) => {
                 error!("failed to parse revspec `{}`: {}",
-                       args.flag_revisions,
+                       args.arg_revisions,
                        err)
             }
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -178,31 +178,6 @@ pub fn check_clean(repo: &Repository) {
     }
 }
 
-pub fn checkout_branch(repo: &Repository, branch_name: &str) {
-    let branch = match repo.find_branch(branch_name, BranchType::Local) {
-        Ok(branch) => branch,
-        Err(err) => {
-            error!("encountered error looking up branch `{}`: {}",
-                   branch_name,
-                   err)
-        }
-    };
-
-    let direct_reference = match branch.get().resolve() {
-        Ok(r) => r,
-        Err(err) => {
-            error!("encountered error resolving reference `{}`: {}",
-                   branch_name,
-                   err)
-        }
-    };
-
-    let commit_oid = direct_reference.target().unwrap();
-    let commit = repo.find_commit(commit_oid).unwrap();
-
-    checkout_commit(repo, &commit);
-}
-
 pub fn checkout_commit(repo: &Repository, commit: &Commit) {
     let mut cb = CheckoutBuilder::new();
     match repo.checkout_tree(commit.as_object(), Some(&mut cb)) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use git2::{Commit, Error as Git2Error, ErrorCode, Object, Repository, Status,
-           STATUS_IGNORED, BranchType};
+           STATUS_IGNORED};
 use git2::build::CheckoutBuilder;
 use std::fs;
 use std::io;


### PR DESCRIPTION
Instead of <branch-name> and --revision there is only <revisions>
now. That is, in order to the last 3 revisions of the master branch,
one writes:

```
    cargo-incremental replay master~2..master
```

instead of something like:

```
    cargo-incremental replay --revisions HEAD~2..HEAD master
```
