### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "cargo-incremental"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0/MIT"
-documentation = "A tool for using and testing rustc's incremental compilation support"
+description = "A tool for using and testing rustc's incremental compilation support"
 repository = "http://github.com/nikomatsakis/cargo-incremental/"
+
 
 [dependencies]
 docopt = "0.6.82"


### PR DESCRIPTION
So we can re-publish on crates.io.