### PR TITLE
Add --skip-tests and --no-debuginfo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,11 +45,12 @@ before execution begins so don't supply a directory with valuable
 contents. =)
 
 Options:
-    --cargo CARGO      path to Cargo.toml [default: Cargo.toml]
-    --work-dir DIR     directory where we can do our work [default: work]
-    --just-current     track just the current projection incrementally, not all deps
-    --cli-log          print all sub-process output instead of writing to files
-    --skip-tests       do not run tests, just compare compilation artifacts
+    --cargo CARGO           path to Cargo.toml [default: Cargo.toml]
+    --work-dir DIR          directory where we can do our work [default: work]
+    --just-current          track just the current projection incrementally, not all deps
+    --cli-log               print all sub-process output instead of writing to files
+    --skip-tests            do not run tests, just compare compilation artifacts
+    --no-debuginfo          compile without debuginfo whe comparing artifacts
 ";
 
 // dead code allowed for now
@@ -65,6 +66,7 @@ pub struct Args {
     flag_just_current: bool,
     flag_cli_log: bool,
     flag_skip_tests: bool,
+    flag_no_debuginfo: bool,
 }
 
 macro_rules! error {

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ Options:
     --work-dir DIR     directory where we can do our work [default: work]
     --just-current     track just the current projection incrementally, not all deps
     --cli-log          print all sub-process output instead of writing to files
+    --skip-tests       do not run tests, just compare compilation artifacts
 ";
 
 // dead code allowed for now
@@ -63,6 +64,7 @@ pub struct Args {
     flag_work_dir: String,
     flag_just_current: bool,
     flag_cli_log: bool,
+    flag_skip_tests: bool,
 }
 
 macro_rules! error {

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -193,7 +193,7 @@ pub fn replay(args: &Args) {
                 util::print_output(&normal_build_result.raw_output);
 
                 println!("\nOUTPUT OF INCREMENTAL BUILD:\n");
-                util::print_output(&normal_build_result.raw_output);
+                util::print_output(&incr_build_result.raw_output);
 
                 error!("incremental build differed from normal build")
             } else {
@@ -215,6 +215,7 @@ pub fn replay(args: &Args) {
                              IncrementalOptions::None)),
              "OK")
         });
+
 
         // INCREMENTAL TESTING -------------------------------------------------
         let incr_test = sub_task_runner.run(INCREMENTAL_TEST, || {
@@ -238,7 +239,16 @@ pub fn replay(args: &Args) {
                 return ((), "skipped");
             }
 
+            let normal_test = normal_test.clone().unwrap();
+            let incr_test = incr_test.unwrap();
+
             if normal_test != incr_test {
+                println!("OUTPUT OF NORMAL TESTS:\n");
+                util::print_output(&normal_test.raw_output);
+
+                println!("\nOUTPUT OF INCREMENTAL TESTS:\n");
+                util::print_output(&incr_test.raw_output);
+
                 error!("incremental tests differed from normal tests")
             } else {
                 ((), "OK")
@@ -414,6 +424,7 @@ fn cargo_test(cargo_dir: &Path,
     TestResult {
         success: output.status.success(),
         results: test_results,
+        raw_output: output,
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,7 +25,7 @@ pub enum IncrementalOptions<'p> {
     CurrentProject(&'p Path),
 }
 
-#[derive(Eq, Debug)]
+#[derive(Eq, Debug, Clone)]
 pub struct BuildResult {
     pub success: bool,
     pub messages: Vec<Message>,
@@ -39,20 +39,28 @@ impl PartialEq for BuildResult {
     }
 }
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Message {
     pub kind: String,
     pub message: String,
     pub location: String,
 }
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Eq, Debug, Clone)]
 pub struct TestResult {
     pub success: bool,
     pub results: Vec<TestCaseResult>,
+    pub raw_output: Output,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
+impl PartialEq for TestResult {
+    fn eq(&self, other: &TestResult) -> bool {
+        self.success == other.success &&
+        self.results == other.results
+    }
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone)]
 pub struct TestCaseResult {
     pub test_name: String,
     pub status: String,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use git2::{Commit, Error as Git2Error, ErrorCode, Object, Repository, Status,
-           STATUS_IGNORED};
+           STATUS_IGNORED, ResetType};
 use git2::build::CheckoutBuilder;
 use std::fs;
 use std::io;
@@ -183,6 +183,15 @@ pub fn check_clean(repo: &Repository) {
     }
     if errors > 0 {
         error!("cannot run with a dirty repository; clean it first");
+    }
+}
+
+pub fn reset_repo(repo: &Repository, commit: &Commit) {
+    let mut cb = CheckoutBuilder::new();
+    if let Err(err) = repo.reset(commit.as_object(),
+                                 ResetType::Hard,
+                                 Some(&mut cb)) {
+        error!("encountered error while resetting repo: {}", err)
     }
 }
 


### PR DESCRIPTION
This PR adds two flags:

- `--skip-tests` allows to ignore tests. Some of the tests are running rather long (e.g. for the regex crate) and we might want to ignore them for at least part of the history.
- `--no-debuginfo` will cause the tool to compile everything without debuginfo, which is good for testing because depending on all spans easily masks other errors in the ICH.