### PR TITLE
Disable unneeded libgit2-rs features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-incremental"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0/MIT"
 description = "A tool for using and testing rustc's incremental compilation support"
@@ -9,9 +9,12 @@ repository = "http://github.com/nikomatsakis/cargo-incremental/"
 
 [dependencies]
 docopt = "0.6.82"
-git2 = "0.4.4"
 regex = "0.1.73"
 rustc-serialize = "0.3.19"
 progress = "0.2"
 log = "0.3"
 env_logger = "0.3"
+
+[dependencies.git2]
+version = "0.4.4"
+default-features = false


### PR DESCRIPTION
This fixes building without Cargo.lock file.