### PR TITLE
Fix re use tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-incremental"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-incremental"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-incremental"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0/MIT"
 description = "A tool for using and testing rustc's incremental compilation support"

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -273,6 +273,12 @@ pub fn replay(args: &Args) {
             if incr_build_result.success {
                 let commit_dir = commits_dir.join(format!("{:04}-{}-incr-build-full-re-use", index, short_id));
                 util::make_dir(&commit_dir);
+
+                // Delete Cargo's target directory so we don't run into Cargo's
+                // smart re-using.
+                util::remove_dir(&target_incr_dir);
+                util::make_dir(&target_incr_dir);
+
                 let mut full_reuse_stats = CompilationStats::default();
                 assert_eq!(full_reuse_stats.modules_reused, 0);
                 assert_eq!(full_reuse_stats.modules_total, 0);


### PR DESCRIPTION
This commit makes sure that we are actually running the compiler when testing for full re-use. If we don't delete Cargo's target directory, Cargo will decide that nothing has changed and thus not even invoke the compiler.

r? @nikomatsakis 