### PR TITLE
Immediately forward cargo output in build-mode.

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -61,9 +61,8 @@ pub fn build(args: &Args) {
                                    Path::new("target"),
                                    incr_options,
                                    &mut stats,
-                                   false);
-
-    util::print_output(&build_result.raw_output);
+                                   false,
+                                   true);
 
     for m in build_result.messages {
         println!("{}", m.message);

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -181,7 +181,8 @@ pub fn replay(args: &Args) {
                          &target_normal_dir,
                          IncrementalOptions::None,
                          &mut stats_normal,
-                         !args.flag_cli_log),
+                         !args.flag_cli_log,
+                         false),
              "OK")
         });
 
@@ -194,7 +195,8 @@ pub fn replay(args: &Args) {
                          &target_incr_dir,
                          incr_options,
                          &mut stats_incr,
-                         !args.flag_cli_log),
+                         !args.flag_cli_log,
+                         false),
              "OK")
         });
 
@@ -288,7 +290,8 @@ pub fn replay(args: &Args) {
                                                    &target_incr_dir,
                                                    incr_options, // NOTE: we are using the same cache dir
                                                    &mut full_reuse_stats,
-                                                   !args.flag_cli_log);
+                                                   !args.flag_cli_log,
+                                                   false);
                 if result_no_change.success {
                     if full_reuse_stats.modules_reused != full_reuse_stats.modules_total {
                         error!("only {} modules out of {} re-used in full re-use test",
@@ -328,7 +331,8 @@ pub fn replay(args: &Args) {
                                                       &target_incr_from_scratch_dir,
                                                       incr_from_scratch_options,
                                                       &mut stats_incr_from_scratch,
-                                                      !args.flag_cli_log);
+                                                      !args.flag_cli_log,
+                                                      false);
                 if !from_scratch_result.success {
                     util::print_output(&from_scratch_result.raw_output);
                     error!("error during (incr-from-scratch) build!");


### PR DESCRIPTION
This should make the `build` sub-command more ergonomic.
(Also, I've recorded the whole development of this feature `:)`)