### PR TITLE
Add --verbose flag for more commandline output.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-incremental"
-version = "0.1.7"
+version = "0.1.9"
 dependencies = [
  "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-incremental"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0/MIT"
 description = "A tool for using and testing rustc's incremental compilation support"

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ Options:
     --cli-log               print all sub-process output instead of writing to files
     --skip-tests            do not run tests, just compare compilation artifacts
     --no-debuginfo          compile without debuginfo whe comparing artifacts
+    --verbose               print more output
 ";
 
 // dead code allowed for now
@@ -67,6 +68,7 @@ pub struct Args {
     flag_cli_log: bool,
     flag_skip_tests: bool,
     flag_no_debuginfo: bool,
+    flag_verbose: bool,
 }
 
 impl Args {
@@ -100,6 +102,10 @@ impl Args {
 
             if self.flag_no_debuginfo {
                 cmd.push_str(" --no-debuginfo");
+            }
+
+            if self.flag_verbose {
+                cmd.push_str(" --verbose");
             }
 
             write!(cmd, " {}", self.arg_revisions).unwrap();
@@ -195,4 +201,10 @@ fn test_args_to_cli_command() {
         .. args.clone()
     };
     assert_eq!(no_debuginfo.to_cli_command(), "cargo-incremental replay --no-debuginfo master~1..master");
+
+    let verbose = Args {
+        flag_verbose: true,
+        .. args.clone()
+    };
+    assert_eq!(verbose.to_cli_command(), "cargo-incremental replay --verbose master~1..master");
 }

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -185,7 +185,7 @@ pub fn replay(args: &Args) {
                          IncrementalOptions::None,
                          &mut stats_normal,
                          !args.flag_cli_log,
-                         false),
+                         args.flag_verbose),
              "OK")
         });
 
@@ -199,7 +199,7 @@ pub fn replay(args: &Args) {
                          incr_options,
                          &mut stats_incr,
                          !args.flag_cli_log,
-                         false),
+                         args.flag_verbose),
              "OK")
         });
 
@@ -294,7 +294,7 @@ pub fn replay(args: &Args) {
                                                    incr_options, // NOTE: we are using the same cache dir
                                                    &mut full_reuse_stats,
                                                    !args.flag_cli_log,
-                                                   false);
+                                                   args.flag_verbose);
                 if result_no_change.success {
                     if full_reuse_stats.modules_reused != full_reuse_stats.modules_total {
                         error!("only {} modules out of {} re-used in full re-use test",
@@ -335,7 +335,7 @@ pub fn replay(args: &Args) {
                                                       incr_from_scratch_options,
                                                       &mut stats_incr_from_scratch,
                                                       !args.flag_cli_log,
-                                                      false);
+                                                      args.flag_verbose);
                 if !from_scratch_result.success {
                     util::print_output(&from_scratch_result.raw_output);
                     error!("error during (incr-from-scratch) build!");


### PR DESCRIPTION
Something makes Windows builds suspiciously slow. Hopefully this will help debugging that.