### PR TITLE
Adapt to new output format of `cargo test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-incremental"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-incremental"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0/MIT"
 description = "A tool for using and testing rustc's incremental compilation support"

--- a/src/build.rs
+++ b/src/build.rs
@@ -76,9 +76,9 @@ pub fn build(args: &Args) {
         println!("{}", m.message);
     }
 
-    let build_reuse = match stats.modules_total as f32 {
-        0.0 => 100.0,
-        n => stats.modules_reused as f32 / n * 100.0,
+    let build_reuse = match stats.modules_total {
+        0 => 100.0,
+        n => stats.modules_reused as f32 / (n as f32) * 100.0,
     };
 
     println!("Modules reused: {} Total: {} Build reuse: {}%",

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -421,6 +421,8 @@ fn cargo_test(cargo_dir: &Path,
                             rustflags));
         }
     }
+    debug!("{:?}", cmd);
+
     let output = cmd.output();
     let output = match output {
         Ok(output) => {
@@ -462,6 +464,8 @@ fn cargo_test(cargo_dir: &Path,
         });
 
     if nb_tests_summary != test_results.len() {
+        util::print_output(&output);
+
         error!("matched a different number of tests ({}) than in the summary ({})",
                test_results.len(),
                nb_tests_summary);

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -452,7 +452,7 @@ fn cargo_test(cargo_dir: &Path,
 
     test_results.sort();
 
-    let summary_regex = Regex::new(r"(?m)(\d+) passed; (\d+) failed; (\d+) ignored; \d+ measured$")
+    let summary_regex = Regex::new(r"(?m)(\d+) passed; (\d+) failed; (\d+) ignored; \d+ measured")
         .unwrap();
 
     let nb_tests_summary = summary_regex.captures_iter(&all_output)


### PR DESCRIPTION
This should fix the problems we've recently seen with [rust-icci/index_list](https://travis-ci.org/rust-icci/index_list).