### PR TITLE
Enable -Zincremental-verify-ich for all tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-incremental"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-incremental"
-version = "0.1.17"
+version = "0.1.18"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0/MIT"
 description = "A tool for using and testing rustc's incremental compilation support"

--- a/src/util.rs
+++ b/src/util.rs
@@ -283,7 +283,8 @@ pub fn cargo_build(cargo_dir: &Path,
                 .env("RUSTFLAGS",
                      format!("-Z incremental={} \
                               -Z incremental-info {} \
-                              -Z incremental-queries",
+                              -Z incremental-queries \
+                              -Z incremental-verify-ich",
                              incr_dir.display(),
                              rustflags));
         }
@@ -293,7 +294,8 @@ pub fn cargo_build(cargo_dir: &Path,
                 .arg("--")
                 .arg("-Z").arg(format!("incremental={}", incr_dir.display()))
                 .arg("-Z").arg("incremental-info")
-                .arg("-Z").arg("incremental-queries");
+                .arg("-Z").arg("incremental-queries")
+                .arg("-Z").arg("incremental-verify-ich");
         }
     }
 


### PR DESCRIPTION
Enable additional tracking verification (and hope that that doesn't cause tests to time out).