### PR TITLE
Always set CARGO_INCREMENTAL to zero.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-incremental"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-incremental"
-version = "0.1.19"
+version = "0.1.20"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0/MIT"
 description = "A tool for using and testing rustc's incremental compilation support"

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -410,6 +410,12 @@ fn cargo_test(cargo_dir: &Path,
     cmd.current_dir(&cargo_dir);
     cmd.env("CARGO_TARGET_DIR", target_dir);
     cmd.arg("test");
+
+    // We are setting rustc's incremental flags manually, so let's
+    // make cargo not interfere. And if we have IncrementalOptions::None then
+    // we explicitly don't want to default to incremental compilation.
+    cmd.env("CARGO_INCREMENTAL", "0");
+
     match incremental {
         IncrementalOptions::None => {}
         IncrementalOptions::AllDeps(incr_dir) |

--- a/src/util.rs
+++ b/src/util.rs
@@ -272,6 +272,12 @@ pub fn cargo_build(cargo_dir: &Path,
     let mut cmd = Command::new("cargo");
     cmd.current_dir(&cargo_dir);
     cmd.env("CARGO_TARGET_DIR", target_dir);
+
+    // We are setting rustc's incremental flags manually, so let's
+    // make cargo not interfere. And if we have IncrementalOptions::None then
+    // we explicitly don't want to default to incremental compilation.
+    cmd.env("CARGO_INCREMENTAL", "0");
+
     match incremental {
         IncrementalOptions::None => {
             cmd.arg("build").arg("-v");
@@ -280,9 +286,6 @@ pub fn cargo_build(cargo_dir: &Path,
             let rustflags = env::var("RUSTFLAGS").unwrap_or(String::new());
             cmd.arg("build")
                 .arg("-v")
-                // We are setting rustc's incremental flags manually, so let's
-                // make cargo not interfere.
-                .env("CARGO_INCREMENTAL", "0")
                 .env("RUSTFLAGS",
                      format!("-Z incremental={} \
                               -Z incremental-info {} \
@@ -298,8 +301,7 @@ pub fn cargo_build(cargo_dir: &Path,
                 .arg("-Z").arg(format!("incremental={}", incr_dir.display()))
                 .arg("-Z").arg("incremental-info")
                 .arg("-Z").arg("incremental-queries")
-                .arg("-Z").arg("incremental-verify-ich")
-                .env("CARGO_INCREMENTAL", "0");
+                .arg("-Z").arg("incremental-verify-ich");
         }
     }
 


### PR DESCRIPTION
Otherwise we run into issues with `cargo test` and we might default incremental compilation in what we expect to be the non-incremental reference build.